### PR TITLE
Fetch Missions from endpoint and save to store

### DIFF
--- a/src/components/FetchMissions.js
+++ b/src/components/FetchMissions.js
@@ -1,0 +1,15 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+const missionsURL = 'https://api.spacexdata.com/v3/missions';
+
+const fetchMissions = createAsyncThunk('missions/fetch', async () => {
+  const response = await fetch(missionsURL);
+  const data = await response.json();
+  return data.map((mission) => ({
+    mission_id: mission.mission_id,
+    mission_name: mission.mission_name,
+    description: mission.description,
+  }));
+});
+
+export default fetchMissions;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -11,11 +11,11 @@ export default function Header() {
           <NavLink className="brand-name" to="/">Space Travelers&apos; Hub</NavLink>
         </div>
         <div className="nav-bar flex">
-          <NavLink className="nav-item" exact activeClassName="underline" to="/">Rockets</NavLink>
-          <NavLink className="nav-item" exact activeClassName="underline" to="/dragons">Dragons</NavLink>
-          <NavLink className="nav-item" exact activeClassName="underline" to="/missions">Missions</NavLink>
+          <NavLink className="nav-item" to="/">Rockets</NavLink>
+          <NavLink className="nav-item" to="/dragons">Dragons</NavLink>
+          <NavLink className="nav-item" to="/missions">Missions</NavLink>
           <hr />
-          <NavLink className="nav-item" exact activeClassName="underline" to="/profile">My Profile</NavLink>
+          <NavLink className="nav-item" to="/profile">My Profile</NavLink>
         </div>
       </div>
       <hr />

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,8 +1,25 @@
-const Missions = () => (
-  <>
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import fetchMissions from './FetchMissions';
+
+const Missions = () => {
+  const dispatch = useDispatch();
+  const missions = useSelector((state) => state.missions.missions);
+
+  useEffect(() => {
+    dispatch(fetchMissions());
+  }, [dispatch]);
+
+  return (
     <div>
-      <h2>missions</h2>
+      {missions?.map((mission) => (
+        <div key={mission.mission_id}>
+          <p>{mission.name}</p>
+          <p>{mission.description}</p>
+        </div>
+      ))}
     </div>
-  </>
-);
+  );
+};
+
 export default Missions;

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
+import fetchMissions from '../../components/FetchMissions';
 
 const initialState = {
   missions: [],
@@ -8,6 +9,13 @@ export const missionsSlice = createSlice({
   name: 'missions',
   initialState,
   reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchMissions.fulfilled, (state, action) => ({
+        ...state,
+        missions: action.payload,
+      }));
+  },
 });
 
 export default missionsSlice.reducer;


### PR DESCRIPTION
In this PR, below were the changes made:

- [Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section](https://github.com/oovillagran/space_travelers/commit/a68d4d61c41fd87afa519079d73f5b795fc68e94).

Once the data are fetched, dispatch an action to store the selected data in Redux store:

mission_id
mission_name
description

This closes #18 